### PR TITLE
Add formatting toggle for email body display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ node_modules
 /public/build
 /.next/
 /out/
+*.tsbuildinfo
 
 fdw.sql
 archives/**/*

--- a/src/app/lists/layout.tsx
+++ b/src/app/lists/layout.tsx
@@ -2,6 +2,8 @@ import { getLists } from "@/models/list"
 import QuickSearch from "@/components/QuickSearch"
 import MobileNav from "@/components/MobileNav"
 import ListNav from "@/components/ListNav"
+import { FormattingProvider } from "@/components/FormattingProvider"
+import FormattingToggle from "@/components/FormattingToggle"
 
 // Revalidate every 60 seconds - this is a read-only archive
 export const revalidate = 60
@@ -17,27 +19,32 @@ export default async function ListsLayout({
   if (!lists) throw new Error("Lists not found")
 
   return (
-    <div className="h-full ">
-      <MobileNav lists={lists} />
-      <div className="hidden md:flex md:w-64 md:flex-col md:fixed md:inset-y-0">
-        <div className="flex flex-col flex-grow border-r pt-5 overflow-y-auto">
-          <div className="flex items-center flex-shrink-0 px-4 text-lg text-blue-400">
-            postgres.email
-          </div>
-          <div className="m-3 flex flex-col my-10">
-            <QuickSearch />
-          </div>
-          <div className="px-5 text-sm">
-            <h4>Lists</h4>
-          </div>
-          <div className="mt-3 flex-grow flex flex-col">
-            <ListNav lists={lists} />
+    <FormattingProvider>
+      <div className="h-full ">
+        <MobileNav lists={lists} />
+        <div className="hidden md:flex md:w-64 md:flex-col md:fixed md:inset-y-0">
+          <div className="flex flex-col flex-grow border-r pt-5 overflow-y-auto">
+            <div className="flex items-center flex-shrink-0 px-4 text-lg text-blue-400">
+              postgres.email
+            </div>
+            <div className="m-3 flex flex-col my-10">
+              <QuickSearch />
+            </div>
+            <div className="px-5 text-sm">
+              <h4>Lists</h4>
+            </div>
+            <div className="mt-3 flex-grow flex flex-col">
+              <ListNav lists={lists} />
+            </div>
+            <div className="border-t border-gray-800 px-2 py-2">
+              <FormattingToggle />
+            </div>
           </div>
         </div>
+        <div className="md:pl-64 flex flex-col flex-1 h-full">
+          <main>{children}</main>
+        </div>
       </div>
-      <div className="md:pl-64 flex flex-col flex-1 h-full">
-        <main>{children}</main>
-      </div>
-    </div>
+    </FormattingProvider>
   )
 }

--- a/src/components/FormattingProvider.tsx
+++ b/src/components/FormattingProvider.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import { createContext, useContext, useState } from "react"
+
+const FormattingContext = createContext({
+  formatted: true,
+  toggleFormatting: () => {},
+})
+
+export const useFormatting = () => useContext(FormattingContext)
+
+export function FormattingProvider({ children }: { children: React.ReactNode }) {
+  const [formatted, setFormatted] = useState(true)
+
+  return (
+    <FormattingContext.Provider
+      value={{ formatted, toggleFormatting: () => setFormatted((f) => !f) }}
+    >
+      {children}
+    </FormattingContext.Provider>
+  )
+}

--- a/src/components/FormattingToggle.tsx
+++ b/src/components/FormattingToggle.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import { useFormatting } from "./FormattingProvider"
+
+export default function FormattingToggle() {
+  const { formatted, toggleFormatting } = useFormatting()
+
+  return (
+    <button
+      onClick={toggleFormatting}
+      className="flex items-center gap-2 px-3 py-2 text-xs text-gray-400 hover:text-gray-200 transition-colors w-full"
+      title={formatted ? "Show plain text" : "Show formatted text"}
+    >
+      <span
+        className={`relative inline-flex h-4 w-7 items-center rounded-full transition-colors ${
+          formatted ? "bg-blue-600" : "bg-gray-600"
+        }`}
+      >
+        <span
+          className={`inline-block h-3 w-3 rounded-full bg-white transition-transform ${
+            formatted ? "translate-x-3.5" : "translate-x-0.5"
+          }`}
+        />
+      </span>
+      <span>Formatting</span>
+    </button>
+  )
+}

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -4,6 +4,7 @@ import Link from "next/link"
 import { useState } from "react"
 import { usePathname } from "next/navigation"
 import clsx from "clsx"
+import FormattingToggle from "./FormattingToggle"
 
 type ListItem = {
   id: string
@@ -55,6 +56,9 @@ export default function MobileNav({ lists }: { lists: ListItem[] }) {
               </Link>
             )
           })}
+          <div className="border-t border-gray-800 pt-2 mt-2">
+            <FormattingToggle />
+          </div>
         </nav>
       )}
     </div>

--- a/src/components/ThreadItem.tsx
+++ b/src/components/ThreadItem.tsx
@@ -3,6 +3,7 @@
 import type { TreeItem } from "performant-array-to-tree"
 import type { Thread } from "@/models/thread"
 import { useState } from "react"
+import { useFormatting } from "./FormattingProvider"
 
 function formatDate(ts: string | null): string {
   if (!ts) return ""
@@ -283,6 +284,11 @@ function FormattedBody({ text }: { text: string | null }) {
   return <>{elements}</>
 }
 
+function PlainBody({ text }: { text: string | null }) {
+  if (!text) return null
+  return <pre className="whitespace-pre-wrap font-mono text-sm">{text}</pre>
+}
+
 export default function ThreadItem({
   tree,
   level,
@@ -293,6 +299,7 @@ export default function ThreadItem({
   markdown: boolean
 }) {
   const [showDetails, setShowDetails] = useState(true)
+  const { formatted } = useFormatting()
   const message: Thread = tree.data
   const children: { data: Thread; children: any }[] = tree.children
 
@@ -363,7 +370,11 @@ export default function ThreadItem({
               isRoot ? "pl-3 pr-3" : "pl-6 pr-3"
             } py-3`}
           >
-            <FormattedBody text={message.body_text} />
+            {formatted ? (
+              <FormattedBody text={message.body_text} />
+            ) : (
+              <PlainBody text={message.body_text} />
+            )}
           </div>
           <div className="thread-footer py-2 border-b border-gray-700" />
 


### PR DESCRIPTION
## Summary
This PR adds a formatting toggle feature that allows users to switch between formatted (HTML-rendered) and plain text views of email bodies throughout the application.

## Key Changes
- **New Context Provider**: Created `FormattingProvider` component to manage formatting state globally across the app
- **Toggle Component**: Added `FormattingToggle` button component with a visual switch UI that appears in both desktop and mobile navigation
- **Plain Text View**: Implemented `PlainBody` component to display email content as preformatted monospace text
- **Conditional Rendering**: Updated `ThreadItem` to render either formatted or plain text based on the toggle state
- **Layout Updates**: Wrapped the lists layout with `FormattingProvider` and integrated the toggle button into both desktop sidebar and mobile navigation
- **Build Config**: Added `*.tsbuildinfo` to `.gitignore` to exclude TypeScript build cache files

## Implementation Details
- The formatting state is managed via React Context (`FormattingContext`) with a simple boolean flag
- The toggle button features a smooth animated switch UI that visually indicates the current state
- Both desktop (sidebar) and mobile (hamburger menu) navigation include the formatting toggle for consistent UX
- The plain text view uses a `<pre>` element with `whitespace-pre-wrap` to preserve original formatting while maintaining readability

https://claude.ai/code/session_01A6j1tprPbZsmMGhEgMXGRa