### PR TITLE
Adopt declarative schema workflow with pgdelta

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -52,7 +52,8 @@ postgres.email/
 │       ├── scripts/         # Script tests
 │       └── site/            # Web app tests
 └── supabase/
-    └── migrations/          # Database migrations
+    ├── database/            # Declarative schema source of truth (SQL files)
+    └── migrations/          # Generated migrations (do not edit directly)
 
 ```
 
@@ -183,35 +184,37 @@ export type ListDetailDataSuccess = NonNullable<ListDetailData["data"]> & {
 
 ### 1. Making Database Schema Changes
 
-**IMPORTANT:** All database changes MUST be made through migrations, not by directly modifying the database.
+**IMPORTANT:** This project uses **declarative schemas**. The source of truth is the SQL files in `supabase/database/`. Do NOT write migrations by hand or use `supabase migration new`.
 
-#### Create a new migration:
-```bash
-# Create a new migration file
-supabase migration new <descriptive_name>
+#### How it works
 
-# Example:
-supabase migration new add_reply_count_to_messages
+The experimental `pgdelta` feature is already enabled in `supabase/config.toml`:
+```toml
+[experimental.pgdelta]
+enabled = true
 ```
 
-This creates a new file in `supabase/migrations/` with a timestamp prefix.
+The SQL files in `supabase/database/` describe what the schema *should* look like. You edit those files, then run sync — the CLI diffs against the current state, generates a migration, and applies it.
 
-#### Write your SQL:
-Edit the migration file and add your SQL:
-```sql
--- supabase/migrations/20240101000000_add_reply_count_to_messages.sql
-ALTER TABLE messages ADD COLUMN reply_count INTEGER DEFAULT 0;
+#### Workflow: edit schema files, then sync
 
-CREATE INDEX messages_reply_count_idx ON messages(reply_count);
+**Step 1:** Edit the relevant SQL file(s) in `supabase/database/` to reflect the desired schema state (e.g. add a column, create a new table/index/view).
+
+**Step 2:** Run sync:
+```bash
+supabase db schema declarative sync
 ```
 
-#### Apply migration locally:
-```bash
-# Apply to local database
-supabase db reset
+The CLI will:
+1. Diff your schema files against the local database
+2. Generate the migration SQL
+3. Prompt you for a migration name
+4. Warn you if there are destructive statements (DROP, etc.)
+5. Apply the migration to the local database
 
-# Or just apply new migrations
-supabase migration up
+#### Non-interactive (for CI or agentic use):
+```bash
+supabase db schema declarative sync --apply --name <migration_name>
 ```
 
 #### Apply to production:
@@ -224,17 +227,11 @@ supabase link --project-ref <project-ref>
 supabase db push
 ```
 
-**Why migrations?**
-- Version controlled schema changes
-- Reproducible across environments
-- Safe rollback capability
-- Team coordination
-- Automatic deployment to production
-
 **Never do this:**
+❌ `supabase migration new` — don't write migrations by hand
 ❌ Direct SQL via Supabase Studio
 ❌ Manual ALTER TABLE in production
-❌ Schema changes without migration files
+❌ Editing migration files in `supabase/migrations/` directly (they are generated)
 
 ### 2. Regenerating Database Types
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -47,3 +47,6 @@ enable_confirmations = true
 [functions.search]
 verify_jwt = false
 # import_map = './import_map.json'
+
+[experimental.pgdelta]
+enabled = true

--- a/supabase/database/schemas/public/tables/mailboxes.sql
+++ b/supabase/database/schemas/public/tables/mailboxes.sql
@@ -1,0 +1,21 @@
+CREATE TABLE public.mailboxes (
+  id            text    NOT NULL,
+  message_count integer
+);
+
+CREATE POLICY "Read only" ON public.mailboxes
+  FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+ALTER TABLE public.mailboxes
+  ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.mailboxes
+  ADD CONSTRAINT mailboxes_pkey PRIMARY KEY (id);
+
+GRANT ALL ON public.mailboxes TO anon;
+
+GRANT ALL ON public.mailboxes TO authenticated;
+
+GRANT ALL ON public.mailboxes TO service_role;

--- a/supabase/database/schemas/public/tables/messages.sql
+++ b/supabase/database/schemas/public/tables/messages.sql
@@ -1,0 +1,53 @@
+CREATE TABLE public.messages (
+  id             text                     NOT NULL,
+  mailbox_id     text,
+  in_reply_to    text,
+  ts             timestamp with time zone,
+  subject        text,
+  from_email     text,
+  to_addresses   jsonb,
+  cc_addresses   jsonb,
+  bcc_addresses  jsonb,
+  from_addresses jsonb,
+  seq_num        integer,
+  size           bigint,
+  attachments    jsonb,
+  body_text      text,
+  embedded_files jsonb,
+  headers        jsonb,
+  embedded_at    timestamp with time zone
+);
+
+CREATE INDEX messages_mailbox_id_idx ON public.messages (mailbox_id);
+
+CREATE INDEX messages_in_reply_to_idx ON public.messages (in_reply_to);
+
+CREATE INDEX idx_messages_mailbox_ts ON public.messages (mailbox_id, ts DESC);
+
+CREATE INDEX idx_messages_mailbox_root_threads ON public.messages (mailbox_id, ts DESC)
+  WHERE in_reply_to IS NULL;
+
+CREATE INDEX messages_embedded_at_idx ON public.messages (embedded_at)
+  WHERE embedded_at IS NULL;
+
+CREATE INDEX messages_ts_idx ON public.messages (ts);
+
+CREATE POLICY "Read only" ON public.messages
+  FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+ALTER TABLE public.messages
+  ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.messages
+  ADD CONSTRAINT messages_mailbox_id_fkey FOREIGN KEY (mailbox_id) REFERENCES public.mailboxes(id);
+
+ALTER TABLE public.messages
+  ADD CONSTRAINT messages_pkey PRIMARY KEY (id);
+
+GRANT ALL ON public.messages TO anon;
+
+GRANT ALL ON public.messages TO authenticated;
+
+GRANT ALL ON public.messages TO service_role;

--- a/supabase/database/schemas/public/views/threads.sql
+++ b/supabase/database/schemas/public/views/threads.sql
@@ -1,0 +1,65 @@
+CREATE VIEW public.threads WITH (security_invoker=on) AS WITH RECURSIVE threads(id, thread_id, mailbox_id, in_reply_to, ts, subject, from_email, to_addresses, cc_addresses, bcc_addresses, from_addresses, seq_num, size, attachments, body_text, embedded_files, headers) AS (
+         SELECT messages.id,
+            messages.id,
+            messages.mailbox_id,
+            messages.in_reply_to,
+            messages.ts,
+            messages.subject,
+            messages.from_email,
+            messages.to_addresses,
+            messages.cc_addresses,
+            messages.bcc_addresses,
+            messages.from_addresses,
+            messages.seq_num,
+            messages.size,
+            messages.attachments,
+            messages.body_text,
+            messages.embedded_files,
+            messages.headers
+           FROM public.messages messages
+          WHERE (messages.in_reply_to IS NULL)
+        UNION
+         SELECT replies.id,
+            threads_1.thread_id,
+            replies.mailbox_id,
+            replies.in_reply_to,
+            replies.ts,
+            replies.subject,
+            replies.from_email,
+            replies.to_addresses,
+            replies.cc_addresses,
+            replies.bcc_addresses,
+            replies.from_addresses,
+            replies.seq_num,
+            replies.size,
+            replies.attachments,
+            replies.body_text,
+            replies.embedded_files,
+            replies.headers
+           FROM (public.messages replies
+             JOIN threads threads_1 ON ((threads_1.id = replies.in_reply_to)))
+        )
+ SELECT id,
+    thread_id,
+    mailbox_id,
+    in_reply_to,
+    ts,
+    subject,
+    from_email,
+    to_addresses,
+    cc_addresses,
+    bcc_addresses,
+    from_addresses,
+    seq_num,
+    size,
+    attachments,
+    body_text,
+    embedded_files,
+    headers
+   FROM threads;
+
+GRANT ALL ON public.threads TO anon;
+
+GRANT ALL ON public.threads TO authenticated;
+
+GRANT ALL ON public.threads TO service_role;


### PR DESCRIPTION
Switches the project to Supabase's declarative schema approach: SQL files in supabase/database/ are the source of truth, and migrations are generated by diffing against the live database via the experimental pgdelta feature.